### PR TITLE
Added reconnect method

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -292,4 +292,17 @@ public abstract class Bot extends BaseBot {
             logger.error("No websocket url returned by Slack.");
         }
     }
+
+    /**
+     * Method to reconnect to websocket
+     *
+     */
+    public void reconnect() {
+    	if (slackService.getWebSocketUrl() != null) {
+            WebSocketConnectionManager manager = new WebSocketConnectionManager(client(), handler(), slackService.getWebSocketUrl());
+            manager.start();
+        } else {
+            logger.error("No websocket url returned by Slack. RTM must first be initialized.");
+        }
+    }
 }

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -289,7 +289,7 @@ public abstract class Bot extends BaseBot {
     }
 
     /**
-     * Starts websocket connection using the existing slackService
+     * Starts websocket connection using the existing slackService.
      */
     public void startWebSocketConnection() {
         if (slackService.getWebSocketUrl() != null) {

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -159,7 +159,7 @@ public abstract class Bot extends BaseBot {
             logger.error("Error sending event: {}. Exception: {}", event.getText(), e.getMessage());
         }
     }
-    
+
     public final void reply(WebSocketSession session, Event event, String text) {
         reply(session, event, new Message(text));
     }
@@ -285,24 +285,19 @@ public abstract class Bot extends BaseBot {
     @PostConstruct
     private void startWebSocketConnection() {
         slackService.startRTM(getSlackToken());
-        if (slackService.getWebSocketUrl() != null) {
-            WebSocketConnectionManager manager = new WebSocketConnectionManager(client(), handler(), slackService.getWebSocketUrl());
-            manager.start();
-        } else {
-            logger.error("No websocket url returned by Slack.");
-        }
+        openConnection();
     }
 
+
     /**
-     * Method to reconnect to websocket
-     *
+     * Open websocket connection using the existing slackService
      */
-    public void reconnect() {
-    	if (slackService.getWebSocketUrl() != null) {
-            WebSocketConnectionManager manager = new WebSocketConnectionManager(client(), handler(), slackService.getWebSocketUrl());
-            manager.start();
-        } else {
-            logger.error("No websocket url returned by Slack. RTM must first be initialized.");
-        }
+    public void openConnection() {
+      if (slackService.getWebSocketUrl() != null) {
+          WebSocketConnectionManager manager = new WebSocketConnectionManager(client(), handler(), slackService.getWebSocketUrl());
+          manager.start();
+      } else {
+          logger.error("No websocket url returned by Slack.");
+      }
     }
 }

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -283,21 +283,20 @@ public abstract class Bot extends BaseBot {
      * and after which your bot becomes live.
      */
     @PostConstruct
-    private void startWebSocketConnection() {
+    private void startRTMAndWebSocketConnection() {
         slackService.startRTM(getSlackToken());
-        openConnection();
+        startWebSocketConnection();
     }
 
-
     /**
-     * Open websocket connection using the existing slackService
+     * Starts websocket connection using the existing slackService
      */
-    public void openConnection() {
-      if (slackService.getWebSocketUrl() != null) {
-          WebSocketConnectionManager manager = new WebSocketConnectionManager(client(), handler(), slackService.getWebSocketUrl());
-          manager.start();
-      } else {
-          logger.error("No websocket url returned by Slack.");
-      }
+    public void startWebSocketConnection() {
+        if (slackService.getWebSocketUrl() != null) {
+            WebSocketConnectionManager manager = new WebSocketConnectionManager(client(), handler(), slackService.getWebSocketUrl());
+            manager.start();
+        } else {
+            logger.error("No websocket url returned by Slack.");
+        }
     }
 }


### PR DESCRIPTION
Solutions for issue #49 and #43 

Adding a reconnect to Bot allows the following (or similar) to be implemented to reconnect on closure:

    @Override
    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
        logger.debug("WebSocket closed: {}, Close Status: {}", session, status.toString());
        this.reconnect();
        logger.debug("WebSocket Reconnected: {}", session);
    }