### PR TITLE
Added attachments to the Event model

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Event.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Event.java
@@ -78,6 +78,7 @@ public class Event {
     @JsonProperty("event_ts")
     private String eventTs;
     private Message message;
+    private Attachment[] attachments;
 
     public int getId() {
         return id;
@@ -481,5 +482,13 @@ public class Event {
 
     public void setMessage(Message message) {
         this.message = message;
+    }
+
+    public Attachment[] getAttachments() {
+        return attachments;
+    }
+
+    public void setAttachments(Attachment[] attachments) {
+        this.attachments = attachments;
     }
 }


### PR DESCRIPTION
STR:

1. click to Share on any message in the Slack channel
2. send and catch in a `@Controller(events = [EventType.MESSAGE])`

Expected:

- I see message content in Event#text
- I see some entity containing quoted message

Reality:

- I see only Event#text, there is no way to get quoted message info

This is a JSON with meaningless fields omitted I get in Bot#handleTextMessage():

> {  
>    "type":"message",
>    "user":"UAYLYAA1H",
>    "text":"quotedText",
>    "team":"TAY7VUZMF",
>    "attachments":[  
>       {  
>          "fallback":"[June 7th, 2018 1:25 PM] Name: Hi, <@UAYLYAA1> and <@UB0NKNEA>",,
>          "author_id":"UAYLYAA1H",
>          "author_subname":"Name",
>          "text":"Hi, <@UAYLYAA1H> and <@UB0NKNEAH>",
>          "author_name":"Name"
>       }
>    ],
>    "channel":"GB1UDQJ2R",
> }