### PR TITLE
Regex Pattern Flags supports 

### DIFF
--- a/jbot-example/src/test/java/example/jbot/slack/SlackBotTest.java
+++ b/jbot-example/src/test/java/example/jbot/slack/SlackBotTest.java
@@ -97,17 +97,6 @@ public class SlackBotTest {
     }
 
     @Test
-    public void When_MessageWithPatternAndPatternFlags_Then_InvokeOnReceiveMessageWithPatternAndPatternFlags() {
-        TextMessage textMessage = new TextMessage("{\"type\": \"message\"," +
-            "\"ts\": \"1358878749.000002\"," +
-            "\"channel\": \"A1E78BACV\"," +
-            "\"user\": \"U023BECGF\"," +
-            "\"text\": \"HEY\"}"); // this matches the pattern with CASE_INSENSITIVE pattern flag on
-        bot.handleTextMessage(session, textMessage);
-        assertThat(capture.toString(), containsString("hey to you too!"));
-    }
-
-    @Test
     public void When_DirectMessageWithPattern_Then_InvokeOnDirectMessage() {
         TextMessage textMessage = new TextMessage("{\"type\": \"message\"," +
                 "\"ts\": \"1358878749.000002\"," +
@@ -116,6 +105,17 @@ public class SlackBotTest {
                 "\"text\": \"as12sd\"}"); // this matches the pattern but it's a direct message instead of message
         bot.handleTextMessage(session, textMessage);
         assertThat(capture.toString(), containsString("this is a direct message"));
+    }
+
+    @Test
+    public void When_MessageWithPatternAndPatternFlags_Then_InvokeOnReceiveMessageWithPatternAndPatternFlags() {
+        TextMessage textMessage = new TextMessage("{\"type\": \"message\"," +
+            "\"ts\": \"1358878749.000002\"," +
+            "\"channel\": \"A1E78BACV\"," +
+            "\"user\": \"U023BECGF\"," +
+            "\"text\": \"HEY\"}"); // this matches the pattern with CASE_INSENSITIVE pattern flag on
+        bot.handleTextMessage(session, textMessage);
+        assertThat(capture.toString(), containsString("hey case insensitive"));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class SlackBotTest {
 
         @Controller(events = EventType.MESSAGE, pattern = "hey", patternFlags = Pattern.CASE_INSENSITIVE)
         public void onReceiveMessageWithPatternAndPatternFlags(WebSocketSession session, Event event) {
-            System.out.println("hey to you too!");
+            System.out.println("hey case insensitive!");
         }
 
         @Controller(events = EventType.PIN_ADDED)

--- a/jbot-example/src/test/java/example/jbot/slack/SlackBotTest.java
+++ b/jbot-example/src/test/java/example/jbot/slack/SlackBotTest.java
@@ -22,6 +22,7 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.util.Arrays;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -93,6 +94,17 @@ public class SlackBotTest {
         assertThat(capture.toString(), containsString("Second group: as"));
         assertThat(capture.toString(), containsString("Third group: 12"));
         assertThat(capture.toString(), containsString("Fourth group: sd"));
+    }
+
+    @Test
+    public void When_MessageWithPatternAndPatternFlags_Then_InvokeOnReceiveMessageWithPatternAndPatternFlags() {
+        TextMessage textMessage = new TextMessage("{\"type\": \"message\"," +
+            "\"ts\": \"1358878749.000002\"," +
+            "\"channel\": \"A1E78BACV\"," +
+            "\"user\": \"U023BECGF\"," +
+            "\"text\": \"HEY\"}"); // this matches the pattern with CASE_INSENSITIVE pattern flag on
+        bot.handleTextMessage(session, textMessage);
+        assertThat(capture.toString(), containsString("hey to you too!"));
     }
 
     @Test
@@ -227,6 +239,11 @@ public class SlackBotTest {
                     "Second group: " + matcher.group(1) + "\n" +
                     "Third group: " + matcher.group(2) + "\n" +
                     "Fourth group: " + matcher.group(3));
+        }
+
+        @Controller(events = EventType.MESSAGE, pattern = "hey", patternFlags = Pattern.CASE_INSENSITIVE)
+        public void onReceiveMessageWithPatternAndPatternFlags(WebSocketSession session, Event event) {
+            System.out.println("hey to you too!");
         }
 
         @Controller(events = EventType.PIN_ADDED)

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/common/Controller.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/common/Controller.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for different Event types in Slack RTM API, Fb Messenger Bot API.
- * 
+ *
  * @author ramswaroop
  * @version 1.0.0, 12/06/2016.
  */
@@ -15,8 +15,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Controller {
     EventType[] events() default EventType.MESSAGE;
-    
+
+    /**
+     * The regex expression to be compiled
+     */
     String pattern() default "";
-    
+
+    /**
+     * Regex pattern match flags, a bit mask that may include
+     * {@link java.util.regex.Pattern#CASE_INSENSITIVE}, {@link java.util.regex.Pattern#MULTILINE}, {@link java.util.regex.Pattern#DOTALL},
+     * {@link java.util.regex.Pattern#UNICODE_CASE}, {@link java.util.regex.Pattern#CANON_EQ}, {@link java.util.regex.Pattern#UNIX_LINES},
+     * {@link java.util.regex.Pattern#LITERAL}, {@link java.util.regex.Pattern#UNICODE_CHARACTER_CLASS}
+     * and {@link java.util.regex.Pattern#COMMENTS}
+     */
+    int patternFlags() default 0;
+
     String next() default "";
 }


### PR DESCRIPTION
I've added the ability to define pattern flags in the controller.

for example, this code will accept the message 'hey' and 'HEY':
```
@Controller(events = EventType.MESSAGE, pattern = "hey", patternFlags = Pattern.CASE_INSENSITIVE)
```

we can define more than one flag. example:
```
@Controller(events = EventType.MESSAGE, pattern = "hey", patternFlags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE)
```

- flag default value = 0
- test added