### PR TITLE
Synchronize sendMessage and make ping task reset possible

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -19,6 +19,7 @@ import org.springframework.web.socket.client.WebSocketConnectionManager;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -310,6 +311,16 @@ public abstract class Bot extends BaseBot {
             manager.start();
         } else {
             logger.error("No web socket url returned by Slack.");
+        }
+    }
+
+    /**
+     * Shutdown ping scheduler when application shuts down.
+     */
+    @PreDestroy
+    public void destroy() {
+        if (pingScheduledExecutorService != null) {
+            pingScheduledExecutorService.shutdownNow();
         }
     }
 

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -41,6 +41,8 @@ public abstract class Bot extends BaseBot {
 
     private static final Logger logger = LoggerFactory.getLogger(Bot.class);
 
+    private final Object sendMessageLock = new Object();
+
     /**
      * Service to access Slack APIs.
      */
@@ -163,7 +165,9 @@ public abstract class Bot extends BaseBot {
             if (reply.getChannel() == null && event.getChannelId() != null) {
                 reply.setChannel(event.getChannelId());
             }
-            session.sendMessage(new TextMessage(reply.toJSONString()));
+            synchronized (sendMessageLock) {
+                session.sendMessage(new TextMessage(reply.toJSONString()));
+            }
             if (logger.isDebugEnabled()) {  // For debugging purpose only
                 logger.debug("Reply (Message): {}", reply.toJSONString());
             }
@@ -328,7 +332,9 @@ public abstract class Bot extends BaseBot {
                 isRunning = true;
                 Message message = new Message();
                 message.setType(EventType.PING.name().toLowerCase());
-                webSocketSession.sendMessage(new TextMessage(message.toJSONString()));
+                synchronized (sendMessageLock) {
+                    webSocketSession.sendMessage(new TextMessage(message.toJSONString()));
+                }
             } catch (Exception e) {
                 logger.error("Error pinging Slack. Slack bot may go offline when not active. Exception: ", e);
             }


### PR DESCRIPTION
This PR attempts to solve multi-threaded access to the WebSocketSession causing `TEXT_PARTIAL_WRITING` errors as detailed in [this ticket](https://github.com/rampatra/jbot/issues/125) along with allowing the Ping task to be reset.

The multi-thread lock to sendMessage should remove partial write errors but I am still a bit confused about how to actually reset the whole system in case the socket session becomes unrecoverable.  

Is it just about calling `startRTMAndWebSocketConnection` again if I can detect that the service is struggling?  Does the "manager" then need to be stored so it can be stopped and started cleanly in this case?