### PR TITLE
Update Readme with the https URL for git cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ can make your bot live right away.
 
 **Running your SlackBot is just 4 easy steps:**
   
-1. Clone this project `$ git clone git@github.com:rampatra/jbot.git`.  
+1. Clone this project `$ git clone https://github.com/rampatra/jbot.git`.  
 2. [Create a slack bot](https://my.slack.com/services/new/bot) and get your slack token.  
 3. Paste the token in [application.properties](/jbot-example/src/main/resources/application.properties) file.  
 4. Run the example application by running `JBotApplication` in your IDE or via commandline: 


### PR DESCRIPTION
## Problem
I tried to clone the repo but got the following error:
<img width="534" alt="Screen Shot 2020-01-07 at 13 34 08" src="https://user-images.githubusercontent.com/7351827/71898907-69c7c300-3152-11ea-96df-65246520a92b.png">

This is because SSH cloning requires an SSH key-pair with github and the computer. 

### Solution
Cloning with https will work for everyone.