### PR TITLE
Fix infinite loops when there is more than 200 direct message channels

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackApiEndpoints.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackApiEndpoints.java
@@ -20,6 +20,6 @@ public class SlackApiEndpoints {
     }
 
     public String getImListApi() {
-        return slackApi + "/im.list?token={token}&limit={limit}&next_cursor={cursor}";
+        return slackApi + "/conversations.list?token={token}&limit={limit}&cursor={cursor}&types=im";
     }
 }

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackService.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackService.java
@@ -63,7 +63,7 @@ public class SlackService {
         try {
             Event event = restTemplate.getForEntity(slackApiEndpoints.getImListApi(), Event.class,
                     slackToken, limit, nextCursor).getBody();
-            imChannelIds.addAll(Arrays.stream(event.getIms()).map(Channel::getId).collect(Collectors.toList()));
+            imChannelIds.addAll(Arrays.stream(event.getChannels()).map(Channel::getId).collect(Collectors.toList()));
             if (event.getResponseMetadata() != null &&
                     !StringUtils.isEmpty(event.getResponseMetadata().getNextCursor())) {
                 Thread.sleep(5000L); // sleep because its a tier 2 api which allows only 20 calls per minute

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Event.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Event.java
@@ -37,7 +37,7 @@ public class Event {
     @JsonProperty("pinned_to")
     private String[] pinnedTo;
     private Channel channel;
-    private Channel[] ims;
+    private Channel[] channels;
     private Item item;
     private Bot bot;
     private File file;
@@ -179,12 +179,12 @@ public class Event {
         this.channel = channel;
     }
 
-    public Channel[] getIms() {
-        return ims;
+    public Channel[] getChannels() {
+        return channels;
     }
 
-    public void setIms(Channel[] ims) {
-        this.ims = ims;
+    public void setChannels(Channel[] channels) {
+        this.channels = channels;
     }
 
     public Item getItem() {


### PR DESCRIPTION
* The original api is cursor, so change next_cursor to cursor
* im.list API will be deprecated, switch to conversations.list
* Remove Event#ims(only used at 1 place) and change to Event#channels.